### PR TITLE
Removing gfortran yum

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,14 +57,6 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-
-# Install the yum requirements defined canonically in the
-# "recipe/yum_requirements.txt" file. After updating that file,
-# run "conda smithy rerender" and this line be updated
-# automatically.
-/usr/bin/sudo -n yum install -y devtoolset-2-gcc-gfortran
-
-
 # Embarking on 3 case(s).
     set -x
     export CONDA_NPY=112

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 335eab9270a06d18134dafe34b5a21fe26fe6926611d7f960d826d82e851abef
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
   skip: true  # [np==111]
   features:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-devtoolset-2-gcc-gfortran


### PR DESCRIPTION
Testing whether or not we need the gfortran yum-requirements, as discussed in #2.