### PR TITLE
[WIP] Make ninja build verbose

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,7 +12,7 @@ cmake $SRC_DIR \
   -DCMAKE_INSTALL_PREFIX=${PREFIX}\
   -DPYTHON_PREFIX=${SP_DIR} \
   
-ninja install
+ninja -v install
 
 # Change a line of code that won't work with new version of python
 sed -i'.original' 's/_object/object/' $SP_DIR/casadi/casadi.py


### PR DESCRIPTION
Please do not merge. For the time being, this is just a test PR to check the compilation flags with which Casadi is built to understand some performance issues in https://github.com/dic-iit/bipedal-locomotion-framework/issues/219 .


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
