### PR TITLE
Avoid incompatibilities between internal casadi qpOASES fork and upstream qpOASES

### DIFF
--- a/recipe/2965.patch
+++ b/recipe/2965.patch
@@ -1,3 +1,12 @@
+From 0f023c2d8a065643370c0be16aeb9959d767b30d Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Wed, 19 Oct 2022 14:53:25 +0200
+Subject: [PATCH 1/2] Add casadi_ prefix to qpOASES namespace
+
+---
+ external_packages/qpOASES/include/qpOASES/Types.hpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/external_packages/qpOASES/include/qpOASES/Types.hpp b/external_packages/qpOASES/include/qpOASES/Types.hpp
 index e9d06439b3..a309e25927 100644
 --- a/external_packages/qpOASES/include/qpOASES/Types.hpp
@@ -21,3 +30,27 @@ index e9d06439b3..a309e25927 100644
 +    #define REFER_NAMESPACE_QPOASES  casadi_qpOASES::
  
  #endif
+ 
+
+From 53b86ad53195931432bd1ebd4ee66e8d26b025cc Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Wed, 19 Oct 2022 15:20:37 +0200
+Subject: [PATCH 2/2] Add alias of casadi_qpOASES to qpOASES
+
+---
+ casadi/interfaces/qpoases/qpoases_interface.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/casadi/interfaces/qpoases/qpoases_interface.hpp b/casadi/interfaces/qpoases/qpoases_interface.hpp
+index 7aea61573f..4023306cd4 100644
+--- a/casadi/interfaces/qpoases/qpoases_interface.hpp
++++ b/casadi/interfaces/qpoases/qpoases_interface.hpp
+@@ -31,6 +31,8 @@
+ #include <casadi/interfaces/qpoases/casadi_conic_qpoases_export.h>
+ #include <qpOASES.hpp>
+ 
++namespace qpOASES = casadi_qpOASES; 
++
+ /** \defgroup plugin_Conic_qpoases Title
+     \par
+ 

--- a/recipe/2965.patch
+++ b/recipe/2965.patch
@@ -1,0 +1,23 @@
+diff --git a/external_packages/qpOASES/include/qpOASES/Types.hpp b/external_packages/qpOASES/include/qpOASES/Types.hpp
+index e9d06439b3..a309e25927 100644
+--- a/external_packages/qpOASES/include/qpOASES/Types.hpp
++++ b/external_packages/qpOASES/include/qpOASES/Types.hpp
+@@ -104,16 +104,16 @@
+ #else
+ 
+     /** Macro for switching on/off the beginning of the qpOASES namespace definition. */
+-    #define BEGIN_NAMESPACE_QPOASES  namespace qpOASES {
++    #define BEGIN_NAMESPACE_QPOASES  namespace casadi_qpOASES {
+ 
+     /** Macro for switching on/off the end of the qpOASES namespace definition. */
+     #define END_NAMESPACE_QPOASES    }
+ 
+     /** Macro for switching on/off the use of the qpOASES namespace. */
+-    #define USING_NAMESPACE_QPOASES  using namespace qpOASES;
++    #define USING_NAMESPACE_QPOASES  using namespace casadi_qpOASES;
+ 
+     /** Macro for switching on/off references to the qpOASES namespace. */
+-    #define REFER_NAMESPACE_QPOASES  qpOASES::
++    #define REFER_NAMESPACE_QPOASES  casadi_qpOASES::
+ 
+ #endif

--- a/recipe/2965.patch
+++ b/recipe/2965.patch
@@ -1,12 +1,28 @@
-From 0f023c2d8a065643370c0be16aeb9959d767b30d Mon Sep 17 00:00:00 2001
+From 5cb7ec6a0a51eba8fae281f60f4c50d736351bf6 Mon Sep 17 00:00:00 2001
 From: Silvio Traversaro <silvio@traversaro.it>
 Date: Wed, 19 Oct 2022 14:53:25 +0200
-Subject: [PATCH 1/2] Add casadi_ prefix to qpOASES namespace
+Subject: [PATCH] Add casadi_ prefix to qpOASES namespace
 
 ---
+ casadi/interfaces/qpoases/qpoases_interface.hpp     | 3 +++
  external_packages/qpOASES/include/qpOASES/Types.hpp | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ 2 files changed, 6 insertions(+), 3 deletions(-)
 
+diff --git a/casadi/interfaces/qpoases/qpoases_interface.hpp b/casadi/interfaces/qpoases/qpoases_interface.hpp
+index 964db15c89..39b4f065c0 100644
+--- a/casadi/interfaces/qpoases/qpoases_interface.hpp
++++ b/casadi/interfaces/qpoases/qpoases_interface.hpp
+@@ -31,7 +31,10 @@
+ #include <casadi/interfaces/qpoases/casadi_conic_qpoases_export.h>
+ #include <qpOASES.hpp>
+ 
++namespace qpOASES = casadi_qpOASES; 
++
+ /** \defgroup plugin_Conic_qpoases
++ c2cb40a7c (Add casadi_ prefix to qpOASES namespace)
+ Interface to QPOases Solver for quadratic programming
+ 
+ */
 diff --git a/external_packages/qpOASES/include/qpOASES/Types.hpp b/external_packages/qpOASES/include/qpOASES/Types.hpp
 index e9d06439b3..a309e25927 100644
 --- a/external_packages/qpOASES/include/qpOASES/Types.hpp
@@ -32,25 +48,3 @@ index e9d06439b3..a309e25927 100644
  #endif
  
 
-From 53b86ad53195931432bd1ebd4ee66e8d26b025cc Mon Sep 17 00:00:00 2001
-From: Silvio Traversaro <silvio@traversaro.it>
-Date: Wed, 19 Oct 2022 15:20:37 +0200
-Subject: [PATCH 2/2] Add alias of casadi_qpOASES to qpOASES
-
----
- casadi/interfaces/qpoases/qpoases_interface.hpp | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git a/casadi/interfaces/qpoases/qpoases_interface.hpp b/casadi/interfaces/qpoases/qpoases_interface.hpp
-index 7aea61573f..4023306cd4 100644
---- a/casadi/interfaces/qpoases/qpoases_interface.hpp
-+++ b/casadi/interfaces/qpoases/qpoases_interface.hpp
-@@ -31,6 +31,8 @@
- #include <casadi/interfaces/qpoases/casadi_conic_qpoases_export.h>
- #include <qpOASES.hpp>
- 
-+namespace qpOASES = casadi_qpOASES; 
-+
- /** \defgroup plugin_Conic_qpoases Title
-     \par
- 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   patches:
     - 2671.patch
     - 2878.patch
+    - 2965.patch
 
 build:
-  number: 14
+  number: 15
   rpaths:
     - lib/
     - lib/{{ name }}/


### PR DESCRIPTION
Fix https://github.com/conda-forge/casadi-feedstock/issues/75 .

Backport of https://github.com/casadi/casadi/pull/2965 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
