### PR TITLE
Test replacement for the RTLD_DEEPBIND environ workaround (casadi/casadi#4373)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,12 @@ source:
     - patches/0004-Bypass-CMake-crosscompiling-conda-forge-CI-issue.patch
     - patches/0005-support-osqp1-backport-pr-4105.patch
     - patches/0006-Fix-FindEigen3-cmake.patch
+    # Test for the replacement of the RTLD_DEEPBIND environ workaround, see
+    # https://github.com/casadi/casadi/issues/4373
+    - patches/0007-Publish-an-owned-environ-snapshot-for-RTLD_DEEPBIND-.patch
 
 build:
-  number: 4
+  number: 5
   rpaths:
     - lib/
     - lib/{{ name }}/
@@ -69,6 +72,10 @@ test:
     - python ipopt_nl.py
     # Regression test for https://github.com/conda-forge/casadi-feedstock/issues/93
     - OMP_CANCELLATION=true OMP_PROC_BIND=true python ipopt_nl.py spral  # [linux]
+    # Same, but with the OMP_ variables set from Python at runtime rather than
+    # exported into the process before start-up: this exercises the setenv path
+    # (environ gets reallocated) before the plugin is dlopen'd.
+    - env -u OMP_CANCELLATION -u OMP_PROC_BIND python -c "import os; os.environ['OMP_CANCELLATION']='TRUE'; os.environ['OMP_PROC_BIND']='TRUE'; exec(open('ipopt_nl.py').read())" spral  # [linux]
     - test $(pip list | grep casadi | tr -s " " | grep $PKG_VERSION | wc -l) -eq 1  # [unix]
     - cmake-package-check casadi --targets casadi::casadi
   requires:

--- a/recipe/patches/0007-Publish-an-owned-environ-snapshot-for-RTLD_DEEPBIND-.patch
+++ b/recipe/patches/0007-Publish-an-owned-environ-snapshot-for-RTLD_DEEPBIND-.patch
@@ -1,0 +1,153 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joris Gillis <joris@yacoda.com>
+Date: Wed, 12 Aug 2026 00:00:00 +0200
+Subject: [PATCH] Publish an owned environ snapshot for RTLD_DEEPBIND loads
+
+The workaround from conda-forge/casadi-feedstock#94 points glibc's orphaned
+.bss environ at the live environ array for the duration of the dlopen, then
+restores it. Two regressions followed upstream:
+
+ * casadi/casadi#4317 -- under CPython the "original" value is NULL, so the
+   restore writes NULL back, and DEEPBIND-loaded code that iterates environ
+   afterwards (the Julia runtime, reached via MadNLP) dereferences it.
+ * casadi/casadi#4373 -- suppressing that restore instead leaves glibc's slot
+   pointing at the live array, which setenv may realloc away, leaving a
+   dangling pointer.
+
+Publish a private copy of the pointer table instead, as suggested by
+topolarity in casadi/casadi#4373: the copy is ours, so glibc can never free
+it, and it therefore never needs to be restored. The strings it points at are
+never freed by glibc's setenv, so the copy stays dereferenceable.
+
+The snapshot is refreshed before and after each load and reallocated only when
+the table actually changed, so a process that loads many libraries without
+touching its environment leaks a single array in total.
+
+This is the change proposed upstream to replace the code originally added by
+recipe/rtld_deepbind_null_environ_workaround.patch. The regression test added
+in #94 (OMP_CANCELLATION=true OMP_PROC_BIND=true python ipopt_nl.py spral)
+is what this patch needs to keep passing.
+---
+--- a/casadi/core/casadi_os.cpp
++++ b/casadi/core/casadi_os.cpp
+@@ -24,6 +24,15 @@
+ #include "exception.hpp"
+ #include "global_options.hpp"
+ #include <bitset>
++#include <cstdlib>
++#include <cstring>
++#ifdef CASADI_WITH_THREAD
++#ifdef CASADI_WITH_THREAD_MINGW
++#include <mingw.mutex.h>
++#else // CASADI_WITH_THREAD_MINGW
++#include <mutex>
++#endif // CASADI_WITH_THREAD_MINGW
++#endif //CASADI_WITH_THREAD
+ 
+ #ifndef _WIN32
+ #ifdef WITH_DEEPBIND
+@@ -105,6 +114,55 @@
+ 
+ #ifdef WITH_DL
+ 
++#ifndef _WIN32
++#ifdef WITH_DEEPBIND
++#if !defined(__APPLE__) && !defined(__EMSCRIPTEN__)
++#if __GLIBC__
++namespace {
++  // Copy relocation gives a process two distinct `environ` objects: the live one in the
++  // executable's .bss, and a permanently-NULL one in glibc's .bss. Code loaded under
++  // RTLD_DEEPBIND binds to the latter and therefore sees no environment at all --
++  // getenv() is unaffected, but anything iterating environ directly (every OpenMP
++  // runtime does, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111556) silently
++  // reads nothing. See also https://github.com/conda-forge/casadi-feedstock/issues/93
++  //
++  // We publish a snapshot into that dead slot. The snapshot is ours, so glibc can never
++  // free it and it never has to be restored -- restoring is what caused casadi#4317
++  // (writes NULL back, later readers null-deref) and casadi#4373 (leaves a pointer that
++  // glibc's setenv may realloc away).
++  char** environ_snapshot = nullptr;
++  std::size_t environ_snapshot_n = 0;
++#ifdef CASADI_WITH_THREAD
++  std::mutex environ_snapshot_mutex;
++#endif //CASADI_WITH_THREAD
++
++  void publish_environ_snapshot() {
++    char*** slot = reinterpret_cast<char***>(dlsym(RTLD_NEXT, "environ"));
++    if (!slot || slot == &environ) return;   // no duplicate symbol: nothing to do
++#ifdef CASADI_WITH_THREAD
++    std::lock_guard<std::mutex> lock(environ_snapshot_mutex);
++#endif //CASADI_WITH_THREAD
++    std::size_t n = 0;
++    if (environ) while (environ[n]) ++n;
++    if (environ_snapshot && n == environ_snapshot_n &&
++        std::memcmp(environ_snapshot, environ, n * sizeof(char*)) == 0) {
++      *slot = environ_snapshot;              // unchanged: republish, allocate nothing
++      return;
++    }
++    char** fresh = static_cast<char**>(std::malloc((n + 1) * sizeof(char*)));
++    if (!fresh) return;                      // OOM: leave the slot as it was
++    if (n) std::memcpy(fresh, environ, n * sizeof(char*));
++    fresh[n] = nullptr;
++    environ_snapshot = fresh;                // previous snapshot deliberately leaked:
++    environ_snapshot_n = n;                  // an earlier plugin may still hold it
++    *slot = environ_snapshot;
++  }
++}  // namespace
++#endif
++#endif
++#endif
++#endif
++
+ handle_t open_shared_library(const std::string& lib, const std::vector<std::string> &search_paths,
+     const std::string& caller, bool global) {
+         std::string resultpath;
+@@ -137,24 +195,9 @@
+         flag |= RTLD_DEEPBIND;
+ 
+         #if __GLIBC__
+-        // Workaround for https://github.com/conda-forge/casadi-feedstock/issues/93
+-        // and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111556
+-        // In a nutshell, if RTLD_DEEPBIND is used and multiple symbols of environ
+-        // (one in executable's .bss and one in glibc .bss)
+-        // are present in the process due to copy relocations, make sure that the
+-        // environ in glibc .bss has the same value of environ in executable .bss
+-        // To avoid that over time the two values diverse due to the use of setenv,
+-        // we restore the original value of glibc .bss's environ at the end of the function
+-
+-        // Check if there is a duplicate environ
+-        char*** p_environ_rtdl_next = reinterpret_cast<char ***>(dlsym(RTLD_NEXT, "environ"));
+-        bool environ_rtdl_next_overridden = false;
+-        char** environ_rtld_next_original_value = NULL;
+-        if (p_environ_rtdl_next && p_environ_rtdl_next != &environ) {
+-          environ_rtld_next_original_value = *p_environ_rtdl_next;
+-          *p_environ_rtdl_next = environ;
+-          environ_rtdl_next_overridden = true;
+-        }
++        // Hand DEEPBIND-loaded code an environment it can iterate. Never restored;
++        // see the comment on publish_environ_snapshot above.
++        publish_environ_snapshot();
+         #endif
+     #endif
+     #endif
+@@ -204,12 +247,12 @@
+ 
+     #ifndef _WIN32
+     #ifdef WITH_DEEPBIND
+-    #ifndef __APPLE__
++    #if !defined(__APPLE__) && !defined(__EMSCRIPTEN__)
+     #if __GLIBC__
+-        if (environ_rtdl_next_overridden) {
+-          *p_environ_rtdl_next = environ_rtld_next_original_value;
+-          environ_rtdl_next_overridden = false;
+-        }
++        // Pick up any setenv the constructors just performed, so code that reads environ
++        // lazily (rather than at load time) does not lag a load behind. Allocates nothing
++        // unless they changed something.
++        publish_environ_snapshot();
+     #endif
+     #endif
+     #endif
+-- 
+2.43.0
+


### PR DESCRIPTION
**Draft / CI validation only — not intended to be merged.** The patch belongs upstream in CasADi; this PR exists to run it against the regression test @traversaro added in #94, as he suggested in [casadi/casadi#4373](https://github.com/casadi/casadi/issues/4373#issuecomment-3596094478).

### Background

The `RTLD_DEEPBIND` + `environ` workaround from #94 points glibc's orphaned `.bss` `environ` at the live `environ` array for the duration of the `dlopen`, then restores it. Two regressions followed upstream:

* [casadi/casadi#4317](https://github.com/casadi/casadi/issues/4317) — under CPython the "original" value is `NULL`, so the restore writes `NULL` back, and DEEPBIND-loaded code that iterates `environ` afterwards (the Julia runtime, reached via MadNLP) dereferences it. Upstream suppressed the restore when the original was `NULL`.
* [casadi/casadi#4373](https://github.com/casadi/casadi/issues/4373) — that suppression leaves glibc's slot pointing at the live array, which `setenv` may `realloc` away, leaving a dangling pointer.

### What this patch does instead

Publishes a *private copy* of the pointer table into the dead slot, as @topolarity suggested in casadi/casadi#4373:

> you can keep the `environ` hack even if in the presence of `setenv`, but you ought to copy the whole array instead of just a pointer to it.

The copy is ours, so glibc can never free it, and it therefore never has to be restored — which removes both regressions by construction. The strings it points at are never freed by glibc's `setenv`, so the copy stays dereferenceable.

The snapshot is refreshed before and after each load, and reallocated only when the pointer table actually changed. A process that loads many libraries without touching its environment leaks one array in total (measured: 500 loads → 992 bytes, one block; 500 loads each preceded by a `setenv` → ~1 KB per mutation).

### Local verification

A library linking `libgomp`, loaded into an executable that has the `environ` copy relocation (as CPython does):

```
raw RTLD_DEEPBIND (no workaround):   omp_get_cancellation()=0  omp_get_max_threads()=16
casadi loader, shell-exported vars:  omp_get_cancellation()=1  omp_get_max_threads()=3
casadi loader, runtime os.environ:   omp_get_cancellation()=1  omp_get_max_threads()=3
```

### Test added

The existing #93 regression test exports the `OMP_` variables before Python starts, so `environ` is never mutated. This PR adds a variant that sets them from Python at runtime, which goes through `setenv` and reallocates the array before the plugin is `dlopen`'d — the exact shape that produced casadi/casadi#4373:

```
env -u OMP_CANCELLATION -u OMP_PROC_BIND python -c "import os; os.environ['OMP_CANCELLATION']='TRUE'; ..." spral  # [linux]
```

cc @traversaro @apozharski

🤖 Generated with [Claude Code](https://claude.com/claude-code)
